### PR TITLE
Dev issue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Spark Vector Connector
+# Spark Vector Connector (0.1)
 
 A library to integrate Vector with Spark, allowing you to load Spark DataFrames/RDDs into Vector in parallel and to consume results of Vector based computations in Spark(SQL).
 This connector works with both Vector SMP and VectorH MPP.
@@ -11,8 +11,8 @@ This connector works with both Vector SMP and VectorH MPP.
 ## Requirements
 
 This library requires:
-* Vector(H) 4.3+
-* Spark 1.5.1
+* Vector(H) 4.2.x (ONLY)
+* Spark 1.5.x
 
 ## Building (from source)
 
@@ -23,7 +23,7 @@ Spark-Vector connector is built with [sbt](http://www.scala-sbt.org/). To build,
 ## Using with Spark shell/submit
 This module can be added to Spark using the `--jars` command line option. Spark shell example (assuming `$SPARK_VECTOR` is the root directory of spark-vector):
 
-    spark-shell --jars $SPARK_VECTOR/target/spark_vector-assembly-1.0-SNAPSHOT.jar
+    spark-shell --jars $SPARK_VECTOR/target/spark_vector-assembly-0.1.jar
 
 Assuming that there is a Vector Installation on node `vectorhost`, instance `VI` and database `databasename`
 
@@ -108,7 +108,7 @@ The Spark-Vector loader is a command line client utility that provides the abili
 Loading CSV files:
 
 ```
-spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-1.0-SNAPSHOT.jar load csv -sf hdfs://namenode:port/tmp/file.csv
+spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-0.1.jar load csv -sf hdfs://namenode:port/tmp/file.csv
 -vh vectorhost -vi VI -vd databasename -tt vector_table -sc " "
 ```
 
@@ -117,14 +117,14 @@ spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/ta
 Loading Parquet files:
 
 ```
-spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-1.0-SNAPSHOT.jar load parquet -sf hdfs://namenode:port/tmp/file.parquet
+spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-0.1.jar load parquet -sf hdfs://namenode:port/tmp/file.parquet
 -vh vectorhost -vi VI -vd databasename -tt vector_table
 ```
 
 The entire list of options can be retrieved with:
 
 ```
-spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-1.0-SNAPSHOT.jar load --help
+spark-submit --class com.actian.spark_vector.loader.Main $SPARK_VECTOR/loader/target/spark_vector_loader-assembly-0.1.jar load --help
 ```
 
 ## Unit testing

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
     organization := "com.actian",
-    version := "1.0-SNAPSHOT",
+    version := "0.1",
     scalaVersion := "2.10.4",
     libraryDependencies ++= commonDeps,
     fork in Test := true,

--- a/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
@@ -42,14 +42,33 @@ object ResultSetIterator {
 
 /** Extracts `Rows` out of a `ResultSet` */
 class ResultSetRowIterator(result: ResultSet) extends ResultSetIterator[Row](result) with Logging with Profiling {
+  import java.sql.Types._
+
   lazy val numColumns = result.getMetaData.getColumnCount
   lazy val row = collection.mutable.IndexedSeq.fill[Any](numColumns)(null)
   implicit lazy val profAccs = profileInit("resultSet extraction")
+  lazy val metadata = result.getMetaData
+
+  def extractColumn(col: Int): Any = metadata.getColumnType(col) match {
+    case BIGINT => result.getLong(col)
+    case BOOLEAN => result.getBoolean(col)
+    case CHAR | NCHAR | NVARCHAR | VARCHAR => result.getString(col)
+    case DATE => result.getDate(col)
+    case DECIMAL | NUMERIC => result.getBigDecimal(col)
+    case DOUBLE => result.getDouble(col)
+    case FLOAT | REAL => result.getFloat(col)
+    case INTEGER => result.getInt(col)
+    case SMALLINT => result.getShort(col)
+    case TIMESTAMP | TIME => result.getTimestamp(col)
+    case TINYINT => result.getByte(col)
+    case _ => result.getObject(col)
+  }
+
   override protected def extractor: ResultSet => Row = { _ =>
     profile("resultSet extraction")
     var col = 0
     while (col < numColumns) {
-      row(col) = result.getObject(col + 1)
+      row(col) = extractColumn(col + 1)
       col += 1
     }
     val ret = Row.fromSeq(row)

--- a/src/main/scala/com/actian/spark_vector/writer/DataStreamClient.scala
+++ b/src/main/scala/com/actian/spark_vector/writer/DataStreamClient.scala
@@ -31,7 +31,7 @@ import com.actian.spark_vector.vector.ErrorCodes
  * @param table to which table this client will load data
  */
 case class DataStreamClient(vectorProps: VectorConnectionProperties,
-  table: String) extends Serializable with Logging {
+    table: String) extends Serializable with Logging {
   private lazy val jdbc = {
     val ret = new VectorJDBC(vectorProps)
     ret.autoCommit(false)

--- a/src/main/scala/com/actian/spark_vector/writer/DataStreamConnector.scala
+++ b/src/main/scala/com/actian/spark_vector/writer/DataStreamConnector.scala
@@ -51,6 +51,10 @@ class DataStreamConnector(writeConf: WriteConf) extends Logging with Serializabl
   }
 
   def skipTableInfo(implicit socket: SocketChannel): Unit = {
-    DataStreamReader.readWithByteBuffer { in => } // skip table information message. TODO(): read at least the expected vectorsize
+    import DataStreamReader._
+    readWithByteBuffer { in => } // column definition header
+    readWithByteBuffer { in => } // actual data
+    readWithByteBuffer { in => } // number of tuples
+    readWithByteBuffer { in => } // ready for data message
   }
 }

--- a/src/main/scala/com/actian/spark_vector/writer/DataStreamSink.scala
+++ b/src/main/scala/com/actian/spark_vector/writer/DataStreamSink.scala
@@ -30,13 +30,13 @@ case class DataStreamSink(implicit socket: SocketChannel) extends VectorSink {
   var pos: Int = 0
 
   private def writeColumn(columnIndex: Int, values: ByteBuffer, markers: ByteBuffer, align_size: Int): Unit = {
+    align(align_size)
+    writeByteBufferNoFlip(values)
+    pos = pos + values.limit()
     if (markers != null) {
       writeByteBufferNoFlip(markers)
       pos = pos + markers.limit()
     }
-    align(align_size)
-    writeByteBufferNoFlip(values)
-    pos = pos + values.limit()
   }
 
   private def align(typeSize: Int): Unit = {

--- a/src/main/scala/com/actian/spark_vector/writer/RowWriter.scala
+++ b/src/main/scala/com/actian/spark_vector/writer/RowWriter.scala
@@ -103,7 +103,7 @@ class RowWriter(tableSchema: Seq[ColumnMetadata]) extends Serializable with Logg
   def bytesToBeFlushed(headerSize: Int, n: Int): Int = (0 until tableSchema.size).foldLeft(headerSize) {
     case (pos, idx) =>
       val buf = columnBufs(idx)
-      pos + padding(pos + (if (tableSchema(idx).nullable) n else 0), buf.getAlignReq) + buf.getBufferSize
+      pos + padding(pos, buf.getAlignReq) + buf.getBufferSize
   }
 
   /** Flushes buffered data to the socket through `sink` */


### PR DESCRIPTION
Fixed the extraction of row values from JDBC ResultSet according to the advertised java.sql.Types.\* types stored in the metadata. This fixes the case where for a tinyint, smallint Vector datatype, the ResultSet would contain a java.lang.Integer instead of a java.lang.Byte/Short. Fixes #3 .
