### PR TITLE
Fixed the extraction of row values from JDBC ResultSet according to t…

### DIFF
--- a/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
@@ -42,14 +42,33 @@ object ResultSetIterator {
 
 /** Extracts `Rows` out of a `ResultSet` */
 class ResultSetRowIterator(result: ResultSet) extends ResultSetIterator[Row](result) with Logging with Profiling {
+  import java.sql.Types._
+
   lazy val numColumns = result.getMetaData.getColumnCount
   lazy val row = collection.mutable.IndexedSeq.fill[Any](numColumns)(null)
   implicit lazy val profAccs = profileInit("resultSet extraction")
+  lazy val metadata = result.getMetaData
+
+  def extractColumn(col: Int): Any = metadata.getColumnType(col) match {
+    case BIGINT => result.getLong(col)
+    case BOOLEAN => result.getBoolean(col)
+    case CHAR | NCHAR | NVARCHAR | VARCHAR => result.getString(col)
+    case DATE => result.getDate(col)
+    case DECIMAL | NUMERIC => result.getBigDecimal(col)
+    case DOUBLE => result.getDouble(col)
+    case FLOAT | REAL => result.getFloat(col)
+    case INTEGER => result.getInt(col)
+    case SMALLINT => result.getShort(col)
+    case TIMESTAMP | TIME => result.getTimestamp(col)
+    case TINYINT => result.getByte(col)
+    case _ => result.getObject(col)
+  }
+
   override protected def extractor: ResultSet => Row = { _ =>
     profile("resultSet extraction")
     var col = 0
     while (col < numColumns) {
-      row(col) = result.getObject(col + 1)
+      row(col) = extractColumn(col + 1)
       col += 1
     }
     val ret = Row.fromSeq(row)


### PR DESCRIPTION
…he advertised java.sql.Types.\* types stored in the metadata. This fixes the case where for a tinyint, smallint Vector datatype, the ResultSet would contain a java.lang.Integer instead of a java.lang.Byte/Short.
