### PR TITLE
Refactoring the decimal col buffer

### DIFF
--- a/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
@@ -16,7 +16,7 @@
 package com.actian.spark_vector.colbuffer.timestamp
 
 import com.actian.spark_vector.colbuffer._
-import com.actian.spark_vector.colbuffer.util.{TimestampConversion, TimeConversion, BigIntegerConversion, PowersOfTen, MillisecondsScale, SecondsInMinute}
+import com.actian.spark_vector.colbuffer.util.{ TimestampConversion, TimeConversion, BigIntegerConversion, PowersOfTen, MillisecondsScale, SecondsInMinute }
 
 import java.math.BigInteger
 import java.nio.ByteBuffer
@@ -42,7 +42,7 @@ private class TimestampLongColumnBuffer(p: TimestampColumnBufferParams) extends 
 }
 
 private class TimestampLongLongColumnBuffer(p: TimestampColumnBufferParams) extends TimestampColumnBuffer(p, LongLongSize) {
-  override protected def putConverted(converted: BigInteger, buffer: ByteBuffer): Unit = buffer.put(BigIntegerConversion.toLongLongByteArray(converted))
+  override protected def putConverted(converted: BigInteger, buffer: ByteBuffer): Unit = BigIntegerConversion.putLongLongByteArray(buffer, converted)
 }
 
 private class TimestampNZConverter extends TimestampConversion.TimestampConverter {

--- a/src/main/scala/com/actian/spark_vector/writer/RowWriter.scala
+++ b/src/main/scala/com/actian/spark_vector/writer/RowWriter.scala
@@ -16,6 +16,7 @@
 package com.actian.spark_vector.writer
 
 import java.sql.{ Date, Timestamp }
+import java.math.BigDecimal
 
 import org.apache.spark.Logging
 
@@ -62,7 +63,7 @@ class RowWriter(tableSchema: Seq[ColumnMetadata], vectorSize: Int) extends Loggi
       case y if y == classTag[Double] => writeValToColumnBuffer[Double]
       case y if y == classTag[Float] => writeValToColumnBuffer[Float]
       case y if y == classTag[String] => writeValToColumnBuffer[String]
-      case y if y == classTag[Number] => writeValToColumnBuffer[Number]
+      case y if y == classTag[BigDecimal] => writeValToColumnBuffer[BigDecimal]
       case y if y == classTag[Date] => writeValToColumnBuffer[Date]
       case y if y == classTag[Timestamp] => writeValToColumnBuffer[Timestamp]
       case y => throw new Exception(s"Unexpected buffer column type ${y}")


### PR DESCRIPTION
Step1: removing unnecessary conversions (were already there in the BigDecimal implementation) and Number-to-BigDecimal interfacing.

Step2:  we now put the BigInteger directly into the ByteBuffer using little-endian ordering

Needs testing too, as we only have large tests up to Decimal(Long) types. However, I don't expect the latter too show any significant gain over what we have for now.
