### PR TITLE
Catching exceptions within the Future callback for load/unload

### DIFF
--- a/src/main/scala/com/actian/spark_vector/vector/Vector.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/Vector.scala
@@ -129,9 +129,8 @@ private[vector] object Vector extends Logging {
       sparkContext.addSparkListener(new SparkListener() {
         private var ended = false
         override def onJobEnd(job: SparkListenerJobEnd) = if (!ended) {
-          client.commit
           client.close
-          logDebug(s"Data stream client connection closed. Unload ended @ ${job.time}.")
+          logDebug(s"Unload job ended @ ${job.time}.")
           ended = true
         }
       })

--- a/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorJDBC.scala
@@ -197,8 +197,11 @@ class VectorJDBC(cxnProps: VectorConnectionProperties) extends Logging {
     rowCount.map(_ == 0).getOrElse(throw new VectorException(SqlException, s"No result for count on table '${tableName}'"))
   }
 
+  /** Check if Vector `JDBC` connection is closed */
+  def isClosed(): Boolean = dbCxn.isClosed
+
   /** Close the Vector `JDBC` connection */
-  def close(): Unit = dbCxn.close
+  def close(): Unit = dbCxn.close()
 
   /** Set auto-commit to ON/OFF for this `JDBC` connection */
   def autoCommit(value: Boolean): Unit = dbCxn.setAutoCommit(value)


### PR DESCRIPTION
- onFailure we log the stacktrace exception as an error and rollback the transaction (w/o closing the connection); we expect that the executors will un-hang when the transactions is unrolled and the job will eventually end along with the JDBC connection (onJobEnd the JDBC connection is closed)
- synchronizing rollback and close methods in order to eliminate race conditions while trying use these calls (e.g. the JDBC connection may be closed already while we're trying to rollback)

@note: when rolling back the transaction Vector _must_ close the datastream connections (which I don't think it does for now)
