### PR TITLE
Fixing the partition id which is passed further to DataStreamReader; the partitionId from taskContext was bogus, the Partition.index should've been used instead.

### DIFF
--- a/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamReader.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamReader.scala
@@ -42,9 +42,9 @@ class DataStreamReader(readConf: VectorEndpointConf, table: String, tableMetadat
 
   /**
    * This function is executed once for each partition of [[ScanRDD]]. Will open a socket connection, read all data assigned
-   * to its corresponding partition (`taskContext.partitionId`) and return a row iterator (leaving the connection opened).
+   * to its corresponding `partitionId` and return a row iterator (leaving the connection opened).
    */
-  def read(taskContext: TaskContext): RowReader = connector.newConnection(taskContext.partitionId) { implicit socket =>
+  def read(partitionId: Int): RowReader = connector.newConnection(partitionId) { implicit socket =>
     val headerInfo = connector.readConnectionHeader()
     RowReader(tableMetadataSchema, headerInfo, DataStreamTap())
   }

--- a/src/main/scala/com/actian/spark_vector/datastream/reader/ScanRDD.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/reader/ScanRDD.scala
@@ -26,7 +26,7 @@ import com.actian.spark_vector.datastream.VectorEndpointConf
 /**
  * `Vector` RDD to load data into `Spark` through `Vector`'s `Datastream API`
  */
-class ScanRDD(@transient private val sc: SparkContext, readConf: VectorEndpointConf, read: TaskContext => RowReader) extends RDD[Row](sc, Nil) with Logging {
+class ScanRDD(@transient private val sc: SparkContext, readConf: VectorEndpointConf, read: Int => RowReader) extends RDD[Row](sc, Nil) with Logging {
   /** Closed state for the datastream connection */
   private var closed = false
   /** Custom row iterator for reading `DataStream`s in row format */
@@ -41,7 +41,7 @@ class ScanRDD(@transient private val sc: SparkContext, readConf: VectorEndpointC
       close(it, "RowReader")
       closed = true
     }
-    it = read(taskContext)
+    it = read(split.index)
     it.asInstanceOf[Iterator[Row]]
   }
 


### PR DESCRIPTION
Fixes #38 
