### PR TITLE
Checking socket.isConnected in readByteBuffer's while loop (and other small nits)

### DIFF
--- a/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamReader.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamReader.scala
@@ -90,7 +90,7 @@ object DataStreamReader extends Logging {
     var i = 0
     buffer.clear()
     buffer.limit(len)
-    while (i < len) {
+    while (i < len && socket.isConnected) {
       val j = socket.read(buffer)
       if (j <= 0) throw new Exception(
         s"Connection to Vector end point has been closed or amount of data communicated does not match the message length")

--- a/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamTap.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/reader/DataStreamTap.scala
@@ -35,7 +35,7 @@ private[reader] case class DataStreamTap(implicit val socket: SocketChannel) ext
   private var isNextVectorBuffered = false
   private var remaining = true
 
-  private def readVector(reuseByteBuffer: ByteBuffer): ByteBuffer = readWithByteBuffer(Option(reuseByteBuffer)) { vectors =>
+  private def readVector(reuseBuffer: ByteBuffer): ByteBuffer = readWithByteBuffer(Option(reuseBuffer)) { vectors =>
     val packetType = vectors.getInt()
     if (packetType != BinaryDataCode && packetType != SuccessCode) throw new Exception(s"Invalid packet type code = ${packetType}.")
     if (vectors.getInt(NumTuplesIndex) == 0) {


### PR DESCRIPTION
While investigating #54 I made a minor change to check the socket connection within the readByteBuffer while loop. Race conditions might appear though because the socket connection can be closed from Vector side as well (and in this case we don't see it unless we read from the socket). I don't know if it's pure luck (or the issue is very hard to repro), but the "Connection to Vector end point has been closed or amount of data communicated does not match the message length" exceptions stopped showing themselves during my tests with a spark.dynamicAllocation.executorIdleTimeout=1 (executors are killed faster).

The container exceptions from the attached log file (see mantis) are expected whenever containers get killed. The SQLListener exceptions though are due to a bug in Spark WebUI, see https://issues.apache.org/jira/browse/SPARK-12339 (and its fix https://github.com/apache/spark/pull/10405/files).

I think is worth anyway to commit this change. 
