### PR TITLE
Timestamps before epoch would be inserted into Vector with +1s.

### DIFF
--- a/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
@@ -37,7 +37,7 @@ private[colbuffer] abstract class TimestampColumnBuffer(p: TimestampColumnBuffer
     if (p.adjustToUTC) {
       TimeConversion.convertLocalTimestampToUTC(source)
     }
-    val convertedSource = p.converter.convert(source.getTime() / PowersOfTen(MillisecondsScale), source.getNanos(), p.cbParams.scale)
+    val convertedSource = p.converter.convert(TimestampConversion.timestampSeconds(source), source.getNanos(), p.cbParams.scale)
     putConverted(convertedSource, buffer)
   }
 

--- a/src/main/scala/com/actian/spark_vector/colbuffer/util/TimeConversion.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/util/TimeConversion.scala
@@ -22,7 +22,7 @@ import java.util.Calendar
 /** Helper functions and constants for `Time` conversions. */
 object TimeConversion {
   @inline private final def timeInNanos(source: Timestamp): Long =
-    (source.getTime / PowersOfTen(MillisecondsScale)) * PowersOfTen(NanosecondsScale) + source.getNanos
+    TimestampConversion.timestampSeconds(source) * PowersOfTen(NanosecondsScale) + source.getNanos
 
   final def normalizeTime(source: Timestamp): Long = normalizeNanos(timeInNanos(source))
 

--- a/src/main/scala/com/actian/spark_vector/colbuffer/util/TimestampConversion.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/util/TimestampConversion.scala
@@ -16,12 +16,15 @@
 package com.actian.spark_vector.colbuffer.util
 
 import java.math.BigInteger
+import java.sql.Timestamp
 
 /** Helper functions and constants for `Timestamp` conversions. */
 object TimestampConversion {
   // scalastyle:off magic.number
   private final val SecondsBeforeEpochBI = BigInteger.valueOf(SecondsBeforeEpoch)
   private final val NanosecondsFactorBI = BigInteger.valueOf(PowersOfTen(NanosecondsScale).toLong)
+
+  def timestampSeconds(t: Timestamp): Long = floorDiv(t.getTime, PowersOfTen(MillisecondsScale))
 
   final def scaleTimestamp(epochSeconds: Long, subsecNanos: Long, scale: Int): BigInteger = {
     val secondsTotal = BigInteger.valueOf(epochSeconds).add(SecondsBeforeEpochBI)

--- a/src/main/scala/com/actian/spark_vector/colbuffer/util/package.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/util/package.scala
@@ -1,7 +1,7 @@
 /*
  * Copyright 2016 Actian Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.actian.spark_vector.colbuffer
+
+import java.sql.Timestamp
 
 /** Util functions for various type conversions */
 package object util {
@@ -31,4 +33,9 @@ package object util {
   final val NanosecondsInHour = 60L * NanosecondsInMinute
   final val NanosecondsInDay = 24L * NanosecondsInHour
   // scalastyle:on magic.number
+
+  def floorDiv(x: Long, y: Long): Long = {
+    val ret = x / y
+    if (ret >= 0 || ret * y == x) ret else ret - 1
+  }
 }

--- a/src/test/scala/com/actian/spark_vector/DataTypeGens.scala
+++ b/src/test/scala/com/actian/spark_vector/DataTypeGens.scala
@@ -23,6 +23,7 @@ object DataTypeGens {
   import org.scalacheck.Gen._
 
   val DefaultMaxNumFields = 10
+  val MaxColumnNameLen = 30
 
   // FIXME DecimalType doesn't exist yet in Spark 1.5.2
   private val decimalTypeGen: Gen[DecimalType] = for {
@@ -40,7 +41,8 @@ object DataTypeGens {
     const(DoubleType),
     const(DateType),
     const(TimestampType),
-    const(StringType))
+    const(StringType),
+    const(DecimalType(38, 12)))
 
   val fieldGen: Gen[StructField] = for {
     name <- identifier
@@ -51,7 +53,7 @@ object DataTypeGens {
   // TODO ugly dance to avoid duplicate field names - find cleaner way
   val schemaGen: Gen[StructType] = for {
     initialNumFields <- choose(1, DefaultMaxNumFields)
-    fieldNames <- listOfN(initialNumFields, identifier)
+    fieldNames <- listOfN(initialNumFields, identifier.map(_.take(MaxColumnNameLen)))
     uniqueFieldNames = fieldNames.distinct
     numFields = uniqueFieldNames.size
     fieldTypes <- listOfN(numFields, dataTypeGen)


### PR DESCRIPTION
Added/fixed tests:
- properly generate dates/timestamps
- generate null values too
- properly verify that the expected output and the result are the same
