### PR TITLE
In environments where Spark executors are multi-threaded, the reused …

### DIFF
--- a/src/main/scala/com/actian/spark_vector/colbuffer/decimal/DecimalColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/decimal/DecimalColumnBuffer.scala
@@ -72,9 +72,11 @@ private object DecimalLongColumnBuffer {
 }
 
 private class DecimalLongLongColumnBuffer(p: ColumnBufferBuildParams) extends DecimalColumnBuffer(p, LongLongSize) {
+  private val byteArray = Array.fill[Byte](LongLongSize)(0: Byte)
+
   override protected def put(unscaled: BigInteger, buffer: ByteBuffer): Unit = BigIntegerConversion.putLongLongByteArray(buffer, unscaled)
 
-  override def get(buffer: ByteBuffer): BigDecimal = new BigDecimal(BigIntegerConversion.getLongLongByteArray(buffer), p.scale)
+  override def get(buffer: ByteBuffer): BigDecimal = new BigDecimal(BigIntegerConversion.getLongLongByteArray(buffer, byteArray), p.scale)
 }
 
 private object DecimalLongLongColumnBuffer {

--- a/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
@@ -64,11 +64,13 @@ private class TimestampLongColumnBuffer(p: TimestampColumnBufferParams) extends 
 }
 
 private class TimestampLongLongColumnBuffer(p: TimestampColumnBufferParams) extends TimestampColumnBuffer(p, LongLongSize) {
+  private val byteArray = Array.fill[Byte](LongLongSize)(0: Byte)
+
   override protected def putConverted(converted: BigInteger, buffer: ByteBuffer): Unit =
     BigIntegerConversion.putLongLongByteArray(buffer, converted)
 
   override protected def getConverted(buffer: ByteBuffer): BigInteger =
-    BigIntegerConversion.getLongLongByteArray(buffer)
+    BigIntegerConversion.getLongLongByteArray(buffer, byteArray)
 }
 
 private class TimestampNZConverter extends TimestampConversion.TimestampConverter {

--- a/src/main/scala/com/actian/spark_vector/colbuffer/util/BigIntegerConversion.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/util/BigIntegerConversion.scala
@@ -20,14 +20,8 @@ import com.actian.spark_vector.colbuffer.LongLongSize
 import java.math.BigInteger
 import java.nio.ByteBuffer
 
-/**
- * Helper functions and constants for `BigInteger` conversions.
- *
- * @note Do not call this object's methods concurrently
- */
+/** Helper functions and constants for `BigInteger` conversions. */
 object BigIntegerConversion {
-  val bigIntArray = Array.fill[Byte](LongLongSize)(0: Byte) // Keep it in big-endian
-
   // scalastyle:off magic.number
   /**
    * Puts a BigInteger to a ByteBuffer in little-endian order.
@@ -59,7 +53,7 @@ object BigIntegerConversion {
   /**
    * Gets a BigInteger from a ByteBuffer in big-endian order.
    */
-  final def getLongLongByteArray(buffer: ByteBuffer): BigInteger = {
+  final def getLongLongByteArray(buffer: ByteBuffer, bigIntArray: Array[Byte] = Array.fill[Byte](LongLongSize)(0: Byte)): BigInteger = {
     var sourceIndex = bigIntArray.length - 1
 
     while (sourceIndex >= 0) {


### PR DESCRIPTION
…big integer array in BigIntegerConversion would be used by multiple tasks/threads. This resulted in random and wrong results.
