### PR TITLE
Eliminate useless RDD map when the input columns match the target col…

### DIFF
--- a/src/main/scala/com/actian/spark_vector/sql/VectorRelation.scala
+++ b/src/main/scala/com/actian/spark_vector/sql/VectorRelation.scala
@@ -63,7 +63,7 @@ private[spark_vector] class VectorRelation(tableRef: TableRef,
           }
           val numRows = rs.getLong(1)
           logDebug(s"Create empty RDD from the count(*) of ${numRows} row(s).")
-          sqlContext.sparkContext.parallelize(1L to numRows).map(_ => InternalRow.empty).asInstanceOf[RDD[Row]]
+          sqlContext.sparkContext.range(0L, numRows).map(_ => InternalRow.empty).asInstanceOf[RDD[Row]]
         }
       }
     } else {

--- a/src/main/scala/com/actian/spark_vector/vector/Vector.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/Vector.scala
@@ -53,8 +53,9 @@ private[vector] object Vector extends Logging {
     } else {
       (rdd, rddSchema)
     }
-    fillWithNulls(inputRDD, inputType, targetSchema,
-      field2Columns.map(i => i.columnName -> i.fieldName).toMap)
+    val colMappingOpt = targetToInput(inputType, targetSchema, field2Columns.map(i => i.columnName -> i.fieldName).toMap)
+    logDebug(s"Mapping of cols before load is $colMappingOpt for inputTypeFields = ${inputType.fields.map(_.name).mkString(",")}, targetTypeFields = ${targetSchema.fields.map(_.name).mkString(",")}")
+    if (colMappingOpt.isDefined) inputRDD.map(row => colMappingOpt.get.map { i => if (i.isDefined) row(i.get) else null }) else inputRDD
   }
 
   private def load(rdd: RDD[Seq[Any]], columnMetadata: Seq[ColumnMetadata], writeConf: VectorEndpointConf): Unit = {


### PR DESCRIPTION
Eliminate useless RDD map when the input columns match the target columns during Spark-Vector load.

Also replaced sc.parallelize with sc.range when generating dataframes with 0 columns (for count(*) type of queries).
