### PR TITLE
External Tables: Incorrect handling of "time with time zone" values 

### DIFF
--- a/src/main/scala/com/actian/spark_vector/colbuffer/time/TimeColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/time/TimeColumnBuffer.scala
@@ -75,13 +75,11 @@ private class TimeNZLZConverter extends TimeConversion.TimeConverter {
 }
 
 private class TimeTZConverter extends TimeConversion.TimeConverter {
-  private final val TimeMask = 0xFFFFFFFFFFFFF800L
-
   override def convert(unscaledNanos: Long, scale: Int): Long =
-    (TimeConversion.scaleNanos(unscaledNanos, scale) << TimeMaskSize) & TimeMask
+    (TimeConversion.scaleNanos(unscaledNanos, scale) << TimeMaskSize)
 
   override def deconvert(scaledNanos: Long, scale: Int): Long =
-    TimeConversion.unscaleNanos(scaledNanos >> TimeMaskSize, scale) - (scaledNanos & ~TimeMask) * NanosecondsInMinute
+    TimeConversion.unscaleNanos(scaledNanos >> TimeMaskSize, scale)
 }
 
 /** Builds a `ColumnBuffer` object for `time` (NZ, TZ, LZ) types. */

--- a/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
+++ b/src/main/scala/com/actian/spark_vector/colbuffer/timestamp/TimestampColumnBuffer.scala
@@ -82,34 +82,15 @@ private class TimestampNZConverter extends TimestampConversion.TimestampConverte
 }
 
 private class TimestampTZConverter extends TimestampConversion.TimestampConverter {
-  // scalastyle:off magic.number
-  private final val TimeMaskBI = new BigInteger(timeMask)
-  private final val SecondsInMinuteBI = BigInteger.valueOf(SecondsInMinute)
-
-  /** Set the 117 most significant bits to 1 and the 11 least significant bits to 0. */
-  private def timeMask: Array[Byte] = {
-    val mask = new Array[Byte](LongLongSize)
-    mask.update(0, 0.toByte)
-    mask.update(1, 248.toByte)
-    var i = 2
-    while (i < mask.length) {
-      mask.update(i, 0xFF.toByte)
-      i += 1
-    }
-    mask
-  }
-
   override def convert(epochSeconds: Long, subsecNanos: Long, scale: Int): BigInteger = {
     val scaledNanos = TimestampConversion.scaleTimestamp(epochSeconds, subsecNanos, scale)
-    scaledNanos.shiftLeft(TimeMaskSize).and(TimeMaskBI)
+    scaledNanos.shiftLeft(TimeMaskSize)
   }
 
   override def deconvert(convertedSource: BigInteger, scale: Int): (Long, Long) = {
-    val timezoneSec = convertedSource.andNot(TimeMaskBI).multiply(SecondsInMinuteBI)
     val (epochSeconds, subsecNanos) = TimestampConversion.unscaleTimestamp(convertedSource.shiftRight(TimeMaskSize), scale)
-    (epochSeconds - timezoneSec.longValue, subsecNanos)
+    (epochSeconds, subsecNanos)
   }
-  // scalastyle:on magic.number
 }
 
 private class TimestampLZConverter extends TimestampNZConverter {

--- a/src/main/scala/com/actian/spark_vector/datastream/writer/RowWriter.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/writer/RowWriter.scala
@@ -45,7 +45,7 @@ class RowWriter(tableColumnMetadata: Seq[ColumnMetadata], headerInfo: DataStream
    */
   private val columnBufs = tableColumnMetadata.map {
     case col =>
-      logDebug(s"Trying to create a write-buffer of vectorsize = ${headerInfo.vectorSize} for column = ${col.name}, type = ${col.typeName}," +
+      logDebug(s"Trying to create a write-buffer of vectorsize = ${headerInfo.vectorSize} for column = ${col.name}, type = ${col.typeName}, " +
         s"precision = ${col.precision}, scale = ${col.scale}, nullable = ${col.nullable}")
       ColumnBuffer.newWriteBuffer(ColumnBufferBuildParams(col.name, col.typeName.toLowerCase, col.precision, col.scale, headerInfo.vectorSize,
         col.nullable))


### PR DESCRIPTION
- Fixed handling of TZ offset in time and timestamps by not subtracting it from the value since X100 already does that
- Fixed bug with the BigInteger mask, used to be formatted in LittleEndian (instead of BigEndian)

Fixes #67 
