### PR TITLE
Fix for Issue II-5795

### DIFF
--- a/src/main/scala/com/actian/spark_vector/datastream/reader/ScanRDD.scala
+++ b/src/main/scala/com/actian/spark_vector/datastream/reader/ScanRDD.scala
@@ -135,7 +135,15 @@ class ScanRDD(@transient private val sc: SparkContext,
 
   override protected def getPartitions: Array[Partition] = {
     if (vpartitions == 0)
-      vpartitions = 8;
+     {
+      val defaultNumberOfPartitions = sc.defaultParallelism
+      var maxNumberOfExecutors = defaultNumberOfPartitions
+      if(sc.getConf.contains("spark.executor.instances"))
+      {
+        maxNumberOfExecutors = sc.getConf.get("spark.executor.instances").toInt
+      }
+      vpartitions = scala.math.min(defaultNumberOfPartitions, maxNumberOfExecutors)
+    }
     (0 until vpartitions).map(idx => new Partition { def index = idx }).toArray
   }
 


### PR DESCRIPTION
The hardcoded number of partitions in conjunction with limiting the number of executors to significantly less than number of partitions leads to a problem on x100 side. If the filled data stream output queues are not fetched then a point is reached, where a partition queue is completely filled up. In this situation, no more input tuples can be processed and hence we have a deadlock situation. 

The fixe tries to mitigate the problem by setting the number of partitions to the "expected" number of executors for the job.