### PR TITLE
Makes job option and extra option keys case insensitive.

### DIFF
--- a/provider/src/main/scala/com/actian/spark_vector/provider/RequestHandler.scala
+++ b/provider/src/main/scala/com/actian/spark_vector/provider/RequestHandler.scala
@@ -126,7 +126,10 @@ class RequestHandler(spark: SparkSession, val auth: ProviderAuth) extends Loggin
 
   /** Given a job part, retrieve its options, if any, or else an empty Map */
   private def getOptions(part: JobPart): Map[String, String] = {
-    var options = part.options.getOrElse(Map.empty[String, String]).filterKeys(k => !part.extraOptions.contains(k.toLowerCase()))
+    var options = part.options.getOrElse(Map.empty[String, String])
+                  .map({case (k,v) => k.toLowerCase -> v})
+                  .filterKeys(k => !part.extraOptions.contains(k.toLowerCase()))
+
     if (part.format.contains("csv") && !options.contains("header")) {
       options + ("header" -> "true");
     } else {
@@ -136,7 +139,9 @@ class RequestHandler(spark: SparkSession, val auth: ProviderAuth) extends Loggin
 
   /** Given a job part, retrieve its extra options, if any, or else an empty Map */
   private def getExtraOptions(part: JobPart): Map[String, String] =
-    part.options.getOrElse(Map.empty[String, String]).filterKeys(k => part.extraOptions.contains(k.toLowerCase()))
+    part.options.getOrElse(Map.empty[String, String])
+    .map({case (k,v) => k.toLowerCase -> v})
+    .filterKeys(k => part.extraOptions.contains(k.toLowerCase()))
   
   /** Parse a Spark ddl schema and create a schema object */
   private def parseSchema(schemaString: String): Option[StructType] = {

--- a/provider/src/main/scala/com/actian/spark_vector/provider/RequestHandler.scala
+++ b/provider/src/main/scala/com/actian/spark_vector/provider/RequestHandler.scala
@@ -229,7 +229,7 @@ class RequestHandler(spark: SparkSession, val auth: ProviderAuth) extends Loggin
          val options = getOptions(part)
          val schemaSpec = getExtraOptions(part).get("schema")
          val filters = getAllFilters(part)
-         val df = ExternalTable.externalTableDataFrame(spark, part.external_reference, format, schemaSpec, options, filters)
+         val df = ExternalTable.externalTableDataFrame(spark, part.external_reference, format, schemaSpec, options, filters, Some(part.column_infos))
          TempTable("src", df)
     }
   }

--- a/provider/src/test/scala/com/actian/spark_vector/provider/CaseInsensitivityTest.scala
+++ b/provider/src/test/scala/com/actian/spark_vector/provider/CaseInsensitivityTest.scala
@@ -1,0 +1,57 @@
+package com.actian.spark_vector.provider
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.apache.spark.sql.SparkSession
+import resource._
+import org.apache.spark.SparkConf
+
+class CaseInsensivitiyTest extends fixture.FunSuite with Matchers with PrivateMethodTester with TableDrivenPropertyChecks
+{
+    override type FixtureParam = SparkSession
+
+    override protected def withFixture(test: OneArgTest): Outcome = {
+        val conf = new SparkConf()
+        .setMaster("local[1]")
+        .setAppName("case sensitivity test")
+        managed(SparkSession.builder.config(conf).getOrCreate()).acquireAndGet { spark =>
+        withFixture(test.toNoArgTest(spark))
+        }
+    }
+
+    test("Job options case insensitive")
+    {
+        implicit spark =>
+        val scenarios =
+        Table(
+            ("input", "result"),
+            (Map("header"-> "true"), Map("header"-> "true")),
+            (Map("HEADER"-> "true"), Map("header"-> "true")),
+            (Map("Header"-> "true"), Map("header"-> "true"))
+        )
+        val getOptions = PrivateMethod[Map[String, String]]('getOptions)
+        val handler = new RequestHandler(spark , ProviderAuth("test", "test"))
+        forAll(scenarios) { (inp, res) =>
+            val jobPart = new JobPart("1", "test", "test op", "path", Some("csv"), Seq(new ColumnInfo("test", new LogicalType("Int", 4, 4), "Int", false, None)), Some(inp), new DataStream("test", "test", Seq(new StreamPerNode(1, 1, "test"))))
+            handler invokePrivate getOptions(jobPart) should be (res)
+        }
+    }
+
+    test("Job extra options case insensitive")
+    {
+        implicit spark =>
+        val scenarios =
+        Table(
+            ("input", "result"),
+            (Map("schema"-> "test", "filter"-> "test"), Map("schema"-> "test", "filter"-> "test")),
+            (Map("SCHEMA"-> "test", "FILTER"-> "test"), Map("schema"-> "test", "filter"-> "test")),
+            (Map("Schema"-> "test", "filtER"-> "test"), Map("schema"-> "test", "filter"-> "test"))
+        )
+        val getExtraOptions = PrivateMethod[Map[String, String]]('getExtraOptions)
+        val handler = new RequestHandler(spark , ProviderAuth("test", "test"))
+        forAll(scenarios) { (inp, res) =>
+            val jobPart = new JobPart("1", "test", "test op", "path", Some("csv"), Seq(new ColumnInfo("test", new LogicalType("Int", 4, 4), "Int", false, None)), Some(inp), new DataStream("test", "test", Seq(new StreamPerNode(1, 1, "test"))))
+            handler invokePrivate getExtraOptions(jobPart) should be (res)
+        }
+    }
+}


### PR DESCRIPTION
Currently, we run into trouble when keys in the OPTION string within a CREATE EXTERNAL TABLE statement are written upper case or mixed case. This minor change fixes this issue.

Today, I extended the pull request with another commit which makes determination of the schema of an external reference more flexible.