### PR TITLE
II-6650: Introduces a new load option -vj which

### DIFF
--- a/loader/src/main/scala/com/actian/spark_vector/loader/command/VectorTempTable.scala
+++ b/loader/src/main/scala/com/actian/spark_vector/loader/command/VectorTempTable.scala
@@ -27,15 +27,16 @@ object VectorTempTable {
 
   private def parseOptions(config: UserOptions): Map[String, String] = {
     val base = Seq("host" -> config.vector.host,
-      "instance" -> config.vector.instance,
-      "database" -> config.vector.database,
-      "port" -> config.vector.port,
-      "table" -> config.vector.targetTable)
+        "database" -> config.vector.database,
+        "table" -> config.vector.targetTable)
+    val jdbcConfig = Seq(config.vector.instance.map("instance" -> _),
+        config.vector.instanceOffset.map("instanceOffset" -> _),
+        config.vector.jdbcPort.map("port" -> _)).flatten
     val optional = Seq(config.vector.user.map("user" -> _),
       config.vector.password.map("password" -> _)).flatten ++
       config.vector.preSQL.map(generateSQLOption("loadpresql", _)).getOrElse(Nil) ++
       config.vector.postSQL.map(generateSQLOption("loadpostsql", _)).getOrElse(Nil)
-    (base ++ optional).toMap
+    (base ++ jdbcConfig ++ optional).toMap
   }
 
   /**

--- a/loader/src/main/scala/com/actian/spark_vector/loader/options/VectorOptions.scala
+++ b/loader/src/main/scala/com/actian/spark_vector/loader/options/VectorOptions.scala
@@ -15,21 +15,22 @@
  */
 package com.actian.spark_vector.loader.options
 
-import com.actian.spark_vector.vector.VectorConnectionProperties
+import com.actian.spark_vector.vector.{VectorConnectionProperties, JDBCPort}
 
 case class VectorOptions(
   host: String = "",
-  instance: String = "",
+  instance: Option[String] = None,
   database: String = "",
   user: Option[String] = None,
   password: Option[String] = None,
-  port: String = "7",
+  instanceOffset: Option[String] = None,
+  jdbcPort: Option[String] = None,
   targetTable: String = "",
   preSQL: Option[Seq[String]] = None,
   postSQL: Option[Seq[String]] = None)
-  
-object VectorOptions {
-  def getConnectionProps(vo: VectorOptions): VectorConnectionProperties =
-    VectorConnectionProperties(vo.host,  vo.instance, vo.database, vo.user, vo.password, vo.port)
 
+object VectorOptions {
+  def getConnectionProps(vo: VectorOptions): VectorConnectionProperties = {
+    VectorConnectionProperties(vo.host,  JDBCPort(vo.instance, vo.instanceOffset, vo.jdbcPort), vo.database, vo.user, vo.password)
+  }
 }

--- a/loader/src/main/scala/com/actian/spark_vector/loader/parsers/Parser.scala
+++ b/loader/src/main/scala/com/actian/spark_vector/loader/parsers/Parser.scala
@@ -52,10 +52,10 @@ sealed case class ArgOption[T: Read, O](
  * Spark Vector load
  *   --help
  *         This tool can be used to load CSV/Parquet/ORC files through Spark to Vector
- *         
+ *
  * Command: load [csv|parquet|orc|json]
  * Read a file and load into Vector
- * 
+ *
  * Command: load csv [options]
  * Load a csv file
  *   -sf <value> | --sourceFile <value>
@@ -68,10 +68,12 @@ sealed case class ArgOption[T: Read, O](
  *         Vector host name
  *   -vi <value> | --vectorInstance <value>
  *         Vector instance
+ *   -vo <value> | --vectorInstOffset <value>
+ *         Vector JDBC instance offset
+ *   -vj <value> | --vectorJDBCPort <value>
+ *         Vector JDBC port
  *   -vd <value> | --vectorDatabase <value>
  *         Vector database
- *   -vo <value> | --vectorPort <value>
- *   			 Vector port
  *   -vu <value> | --vectorUser <value>
  *         Vector user
  *   -vp <value> | --vectorPass <value>
@@ -82,7 +84,7 @@ sealed case class ArgOption[T: Read, O](
  *         Queries to execute in Vector before loading, separated by ';'
  *   -postSQL <value> | --postSQL <value>
  *         Queries to execute in Vector after loading, separated by ';'
- *         
+ *
  *   -h <value> | --header <value>
  *         Comma separated string with CSV column names and datatypes, e.g. "col1 int, col2 string,"
  *   -sh <value> | --skipHeader <value>
@@ -120,7 +122,7 @@ sealed case class ArgOption[T: Read, O](
  *         PERMISSIVE - sets other fields to null in corrupted records
  *         DROPMALFORMED - ignore corrupted records
  *         FAILFAST - throws an exception on corrupted record
- *         
+ *
  * Command: load parquet [options]
  * Load a parquet file
  *   -sf <value> | --sourceFile <value>
@@ -131,10 +133,12 @@ sealed case class ArgOption[T: Read, O](
  *         Vector host name
  *   -vi <value> | --vectorInstance <value>
  *         Vector instance
+ *   -vo <value> | --vectorInstOffset <value>
+ *         Vector JDBC instance offset
+ *   -vj <value> | --vectorJDBCPort <value>
+ *         Vector JDBC port
  *   -vd <value> | --vectorDatabase <value>
  *         Vector database
- *   -vo <value> | --vectorPort <value>
- *   			 Vector port
  *   -vu <value> | --vectorUser <value>
  *         Vector user
  *   -vp <value> | --vectorPass <value>
@@ -145,7 +149,7 @@ sealed case class ArgOption[T: Read, O](
  *         Queries to execute in Vector before loading, separated by ';'
  *   -postSQL <value> | --postSQL <value>
  *         Queries to execute in Vector after loading, separated by ';'
- *         
+ *
  * Command: load orc [options]
  * Load an orc file
  *   -sf <value> | --sourceFile <value>
@@ -156,10 +160,12 @@ sealed case class ArgOption[T: Read, O](
  *         Vector host name
  *   -vi <value> | --vectorInstance <value>
  *         Vector instance
+ *   -vo <value> | --vectorInstOffset <value>
+ *         Vector JDBC instance offset
+ *   -vj <value> | --vectorJDBCPort <value>
+ *         Vector JDBC port
  *   -vd <value> | --vectorDatabase <value>
  *         Vector database
- *   -vo <value> | --vectorPort <value>
- *   			 Vector port
  *   -vu <value> | --vectorUser <value>
  *         Vector user
  *   -vp <value> | --vectorPass <value>
@@ -170,7 +176,7 @@ sealed case class ArgOption[T: Read, O](
  *         Queries to execute in Vector before loading, separated by ';'
  *   -postSQL <value> | --postSQL <value>
  *         Queries to execute in Vector after loading, separated by ';'
- *         
+ *
  * Command: load json [options]
  * Load a JSON file
  *   -sf <value> | --sourceFile <value>
@@ -181,10 +187,12 @@ sealed case class ArgOption[T: Read, O](
  *         Vector host name
  *   -vi <value> | --vectorInstance <value>
  *         Vector instance
+ *   -vo <value> | --vectorInstOffset <value>
+ *         Vector JDBC instance offset
+ *   -vj <value> | --vectorJDBCPort <value>
+ *         Vector JDBC port
  *   -vd <value> | --vectorDatabase <value>
  *         Vector database
- *   -vo <value> | --vectorPort <value>
- *   			 Vector port
  *   -vu <value> | --vectorUser <value>
  *         Vector user
  *   -vp <value> | --vectorPass <value>
@@ -195,7 +203,7 @@ sealed case class ArgOption[T: Read, O](
  *         Queries to execute in Vector before loading, separated by ';'
  *   -postSQL <value> | --postSQL <value>
  *         Queries to execute in Vector after loading, separated by ';'
- *         
+ *
  *   -h <value> | --header <value>
  *         Comma separated string with JSON column names and datatypes, e.g. "col1 int, col2 string,"
  *   -ps <value> | --primitivesAsString <value>
@@ -237,16 +245,18 @@ object Args {
   val parquetLoad = new ArgDescription("parquet", "parquet", "Load a parquet file")
   val orcLoad = new ArgDescription("orc", "orc", "Load an orc file")
   val jsonLoad = new ArgDescription("json", "json", "Load a json file")
- 
+
   // Vector arguments
   val vectorHost = ArgOption[String, String](
     "vectorHost", "vh", "Vector host name", _.vector.host, updateVector((o, v) => o.copy(host = v)), true)
-  val vectorInstance = ArgOption[String, String](
-    "vectorInstance", "vi", "Vector instance", _.vector.instance, updateVector((o, v) => o.copy(instance = v)), true)
+  val vectorInstance = ArgOption[String, Option[String]](
+    "vectorInstance", "vi", "Vector instance", _.vector.instance, updateVector((o, v) => o.copy(instance = Some(v))), false)
+  val vectorInstOffset = ArgOption[String, Option[String]](
+    "vectorInstOffset", "vo", "Vector JDBC instance offset", _.vector.instanceOffset, updateVector((o, v) => o.copy(instanceOffset = Some(v))), false)
+  val vectorJDBCPort = ArgOption[String, Option[String]](
+    "vectorJDBCPort", "vj", "Vector JDBC port", _.vector.jdbcPort, updateVector((o, v) => o.copy(jdbcPort = Some(v))), false)
   val vectorDatabase = ArgOption[String, String](
     "vectorDatabase", "vd", "Vector database", _.vector.database, updateVector((o, v) => o.copy(database = v)), true)
-  val vectorPort = ArgOption[String, String](
-    "vectorPort", "vo", "Vector port", _.vector.port, updateVector((o, v) => o.copy(port = v)), false)
   val vectorUser = ArgOption[String, Option[String]](
     "vectorUser", "vu", "Vector user", _.vector.user, updateVector((o, v) => o.copy(user = Some(v))), false)
   val vectorPassword = ArgOption[String, Option[String]](
@@ -258,7 +268,7 @@ object Args {
   val postSQL = ArgOption[Seq[String], Option[Seq[String]]](
     "postSQL", "postSQL", "Queries to execute in Vector after loading, separated by ';'", _.vector.postSQL, updateVector((o, v) => o.copy(postSQL = Some(v))), false)
 
-  val vectorArgs = Seq(vectorHost, vectorInstance, vectorDatabase, vectorPort, vectorUser, vectorPassword, vectorTargetTable, preSQL, postSQL)
+  val vectorArgs = Seq(vectorHost, vectorInstance, vectorInstOffset, vectorJDBCPort, vectorDatabase, vectorUser, vectorPassword, vectorTargetTable, preSQL, postSQL)
 
   // Generic arguments
   val inputFile = ArgOption[String, String](
@@ -267,7 +277,7 @@ object Args {
     "cols", "cols", "Comma separated string containing only column names to load", _.general.colsToLoad, updateGeneral((o, v) => o.copy(colsToLoad = Some(v.split(",").map(_.trim())))), false)
   val createTable = ArgOption[Boolean, Option[Boolean]](
     "createTable", "ct", "Whether the table should be created", _.general.createTable, updateGeneral((o, v) => o.copy(createTable = Option(v))), false)
-  
+
   val generalArgs = Seq(inputFile, colsForLoad, createTable)
 
   // CSV arguments
@@ -288,7 +298,7 @@ object Args {
   val ignoreLeading = ArgOption[Boolean, Option[Boolean]](
     "ignoreLeadingWS", "il", "Whether leading whitespaces on values are skipped", _.csv.ignoreLeading, updateCSV((o, v) => o.copy(ignoreLeading = Option(v))), false)
   val ignoreTrailing = ArgOption[Boolean, Option[Boolean]](
-    "ignoreTrailingWS", "it", "Whether trailing whitespaces on values are skipped", _.csv.ignoreTrailing, updateCSV((o, v) => o.copy(ignoreTrailing = Option(v))), false) 
+    "ignoreTrailingWS", "it", "Whether trailing whitespaces on values are skipped", _.csv.ignoreTrailing, updateCSV((o, v) => o.copy(ignoreTrailing = Option(v))), false)
   val nullValue = ArgOption[String, Option[String]](
     "nullValue", "nv", "String representation of a null value", _.csv.nullValue, updateCSV((o, v) => o.copy(nullValue =  Option(v))), false)
   val nanValue = ArgOption[String, Option[String]](
@@ -306,7 +316,7 @@ object Args {
   val header = ArgOption[String, Option[Seq[_]]](
     "header", "h", "Comma separated string with CSV column names and datatypes, e.g. \"col1 int, col2 string,\"", _.csv.header, updateCSV((o, v) => o.copy(header = Some(v.split(",")))), false)
 
-	// JSON arguments
+    // JSON arguments
   val primitivesAsStr = ArgOption[Boolean, Option[Boolean]](
     "primitivesAsString", "ps", "Infer all primitive values as a string type", _.json.primitivesAsString, updateJSON((o, v) => o.copy(primitivesAsString = Option(v))), false)
   val allowComments = ArgOption[Boolean, Option[Boolean]](
@@ -327,8 +337,8 @@ object Args {
     "parseMode", "pm", "Set parse mode for dealing with corrupt records during parsing", _.json.parseMode, updateJSON((o, v) => o.copy(parseMode = Option(v))), false)
   val headerJson = ArgOption[String, Option[Seq[_]]](
     "header", "h", "Comma separated string with JSON column names and datatypes, e.g. \"col1 int, col2 string,\"", _.json.header, updateJSON((o, v) => o.copy(header = Some(v.split(",")))), false)
-  
-  val csvArgs = Seq(header, hRow, inferSchema, encode, separatorChar, quoteChar, escapeChar, commentChar, 
+
+  val csvArgs = Seq(header, hRow, inferSchema, encode, separatorChar, quoteChar, escapeChar, commentChar,
     ignoreLeading, ignoreTrailing, nullValue, nanValue, positiveInf, negativeInf, dateFormat, timestampFormat, parseMode)
   val jsonArgs = Seq(headerJson, primitivesAsStr, allowComments, allowUnquoted, allowSingleQuotes, allowLeadingZeros, allowEscapingAny, allowUnqCtrlChars, multiline, parseModeJson)
   val parquetArgs = Seq.empty[ArgOption[_, _]]
@@ -339,9 +349,9 @@ object Args {
   val orcOptions: Seq[ArgOption[_, _]] = generalArgs ++ vectorArgs ++ orcArgs
   val jsonOptions: Seq[ArgOption[_, _]] = generalArgs ++ vectorArgs ++ jsonArgs
   val modeToOptions = Map(
-      csvLoad.longName -> csvOptions, 
-      parquetLoad.longName -> parquetOptions, 
-      orcLoad.longName -> orcOptions,  
+      csvLoad.longName -> csvOptions,
+      parquetLoad.longName -> parquetOptions,
+      orcLoad.longName -> orcOptions,
       jsonLoad.longName -> jsonOptions)
 }
 
@@ -370,13 +380,13 @@ object Parser extends scopt.OptionParser[UserOptions]("spark-submit --class com.
         .action((_, options) => options.copy(mode = orcLoad.longName))
         .abbr(orcLoad.shortName)
         .text(orcLoad.description)
-        .children(orcOptions.map(_.asOpt(this)): _*),        
+        .children(orcOptions.map(_.asOpt(this)): _*),
       cmd(jsonLoad.longName)
         .action((_, options) => options.copy(mode = jsonLoad.longName))
         .abbr(jsonLoad.shortName)
         .text(jsonLoad.description)
         .children(jsonOptions.map(_.asOpt(this)): _*))
-        
+
 
   checkConfig { options =>
     if (options.mode.isEmpty || options.mode == load.longName) {
@@ -394,7 +404,15 @@ object Parser extends scopt.OptionParser[UserOptions]("spark-submit --class com.
         if (cur.extractor(options).isEmpty) acc :+ cur.longName else acc
       })
     if (missing.isEmpty) {
-      success
+        val instance = "[a-zA-Z]+".r
+        val offset = "[0-9]+".r
+        val port = "[a-zA-Z]*[0-9]+".r
+        (options.vector.instance, options.vector.instanceOffset, options.vector.jdbcPort) match {
+            case (Some(instance()), None, None) |
+                 (Some(instance()), Some(offset()), None) |
+                 (None, None, Some(port())) => success
+            case _ => failure("Error is: EITHER instance id (vi) and optional instance offset (vo) OR real JDBC port number (vj) required!")
+        }
     } else {
       failure("Errors are: " + missing.map(n => s"${n} missing").mkString(";"))
     }

--- a/loader/src/test/scala/com/actian/spark_vector/loader/parsers/parser/ParserTest.scala
+++ b/loader/src/test/scala/com/actian/spark_vector/loader/parsers/parser/ParserTest.scala
@@ -136,7 +136,7 @@ class ParserTest extends FunSuite with Matchers with PropertyChecks {
       longKey(vectorPassword), "p@55",
       longKey(vectorTargetTable), "testtbl",
       longKey(inputFile), """c:\tmp\test.csv""")
-    val portValuesSets = Seq(None, Some(""), Some("VW"), Some("VW7"), Some("9999"))
+    val portValuesSets = Seq(None, Some(""), Some("VW"), Some("VW7"), Some("9999"), Some("A1"))
     val keyMapperCandidates = Seq(LongKeyMapper, ShortKeyMapper)
 
     val testData = for {
@@ -162,6 +162,7 @@ class ParserTest extends FunSuite with Matchers with PropertyChecks {
                  (Some(""), _, _) | (_, Some(""), _) | (_, _, Some("")) |
                  (Some("VW7"), _, _) | (_, Some("VW7"), _) |
                  (_, Some("VW"), _) | (_, _, Some("VW")) |
+                 (_, Some("A1"), _) | (_, _, Some("A1")) |
                  (Some("9999"), _, _) | (None, Some("9999"), _) => parser.parse(testsequence, UserOptions()) shouldBe None
             case _ => parser.parse(testsequence, UserOptions()) shouldBe defined
         }

--- a/src/main/scala/com/actian/spark_vector/sql/TableRef.scala
+++ b/src/main/scala/com/actian/spark_vector/sql/TableRef.scala
@@ -15,26 +15,29 @@
  */
 package com.actian.spark_vector.sql
 
-import com.actian.spark_vector.vector.VectorConnectionProperties
+import com.actian.spark_vector.vector.{VectorConnectionProperties, JDBCPort}
+import scala.annotation.meta.param
 
 /** A reference to a `Vector` table */
-case class TableRef(host: String, instance: String, database: String, port: String, user: Option[String], password: Option[String], table: String, cols: Seq[String]) {
-  def toConnectionProps: VectorConnectionProperties = VectorConnectionProperties(host, instance, database, user, password, port)
+case class TableRef(host: String, port: JDBCPort, database: String, user: Option[String], password: Option[String], table: String, cols: Seq[String]) {
+  def toConnectionProps: VectorConnectionProperties = VectorConnectionProperties(host, port, database, user, password)
 }
 
 object TableRef {
   def apply(parameters: Map[String, String]): TableRef = {
     val host = parameters("host")
-    val instance = parameters("instance")
+    val instance = parameters.get("instance")
     val database = parameters("database")
     val table = parameters("table")
-    val port = if (parameters.contains("port")) parameters("port") else "7"
-    val user = if (parameters.contains("user")) Some(parameters("user")) else None
-    val password = if (parameters.contains("password")) Some(parameters("password")) else None
+    val instanceOffset = parameters.get("instanceOffset")
+    val port = parameters.get("port")
+    val user = parameters.get("user");
+    val password = parameters.get("password")
     val colsToLoad = parameters.get("cols").map(_.split(",").map(_.trim).toSeq).getOrElse(Nil)
-    TableRef(host, instance, database, port, user, password, table, colsToLoad)
+
+    TableRef(host, JDBCPort(instance, instanceOffset, port), database, user, password, table, colsToLoad)
   }
 
   def apply(connectionProps: VectorConnectionProperties, table: String): TableRef = TableRef(connectionProps.host,
-    connectionProps.instance, connectionProps.database, connectionProps.port, connectionProps.user, connectionProps.password, table, Nil)
+    connectionProps.port, connectionProps.database, connectionProps.user, connectionProps.password, table, Nil)
 }

--- a/src/main/scala/com/actian/spark_vector/vector/VectorConnectionProperties.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorConnectionProperties.scala
@@ -15,19 +15,57 @@
  */
 package com.actian.spark_vector.vector
 
+
+trait JDBCPort extends Serializable {
+    def value: String
+
+    override def toString = value
+}
+
+object JDBCPort {
+    private class JDBCPortImpl(port: String) extends JDBCPort { override def value = {port} }
+
+    private def apply(instance: String, instanceOffset: Option[String]): JDBCPort = {
+        require(instance.matches("[a-zA-Z]+"), "The instance property and cannot be empty or a number")
+        val offset: String = {
+            instanceOffset match {
+                case Some(x) => {
+                    require(x.matches("[0-9]+"), "Instance offset cannot be empty and has to be a number!")
+                    x}
+                case None => "7"
+            }
+        }
+        new JDBCPortImpl(s"${instance}${offset}")
+    }
+
+    private def apply(port: String): JDBCPort = {
+        val regex = """[a-zA-Z]*[0-9]+""".r
+        port match {
+            case regex() => new JDBCPortImpl(port)
+            case _ => throw new IllegalArgumentException("Port is not valid!")
+        }
+    }
+
+    def apply(instance: Option[String], instanceOffset: Option[String], port: Option[String]): JDBCPort = {
+        require((instance.isDefined && !port.isDefined) || (!instance.isDefined && !instanceOffset.isDefined && port.isDefined),
+            "EITHER instance id and optional instance offset OR real port number required!")
+        instance match {
+            case Some(x) => JDBCPort(x, instanceOffset)
+            case None => JDBCPort(port.get)
+        }
+    }
+}
+
 /**
  * Container for Vector connection properties.
  */
 case class VectorConnectionProperties(host: String,
-    instance: String,
+    port: JDBCPort,
     database: String,
     user: Option[String] = None,
-    password: Option[String] = None,
-    port: String = "7") extends Serializable {
+    password: Option[String] = None) extends Serializable {
   require(host != null && host.length > 0, "The host property is required and cannot be null or empty")
-  require(instance != null && instance.length > 0, "The instance property is required and cannot be null or empty")
   require(database != null && database.length > 0, "The database property is required and cannot be null or empty")
-  require(port != null && port.length > 0 && port.forall(Character.isDigit(_)), "The port property must be an integer")
 
-  def toJdbcUrl: String = s"jdbc:ingres://${host}:${instance}${port}/${database}"
+  def toJdbcUrl: String = s"jdbc:ingres://${host}:${port}/${database}"
 }

--- a/src/main/scala/com/actian/spark_vector/vector/VectorConnectionProperties.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorConnectionProperties.scala
@@ -18,30 +18,34 @@ package com.actian.spark_vector.vector
 
 trait JDBCPort extends Serializable {
     def value: String
-
     override def toString = value
 }
 
 object JDBCPort {
+    val defaultInstanceOffset = "7" //default used by Vector(H), e.g. VW7
+    val instanceRegex = "[a-zA-Z][a-zA-Z0-9]" // e.g. VW, A1
+    val offsetOrPortRegex = "[0-9]+" // e.g. 7
+    val fullPortRegex = "(" + instanceRegex + ")" + "{0,1}" + offsetOrPortRegex // e.g. VW7 or A17 or 9999
+
     private class JDBCPortImpl(port: String) extends JDBCPort { override def value = {port} }
 
     private def apply(instance: String, instanceOffset: Option[String]): JDBCPort = {
-        require(instance.matches("[a-zA-Z]+"), "The instance property and cannot be empty or a number")
+        require(instance.matches(instanceRegex), "The instance property and cannot be empty or a number")
         val offset: String = {
             instanceOffset match {
                 case Some(x) => {
-                    require(x.matches("[0-9]+"), "Instance offset cannot be empty and has to be a number!")
+                    require(x.matches(offsetOrPortRegex), "Instance offset cannot be empty and has to be a number!")
                     x}
-                case None => "7"
+                case None => defaultInstanceOffset
             }
         }
         new JDBCPortImpl(s"${instance}${offset}")
     }
 
     private def apply(port: String): JDBCPort = {
-        val regex = """[a-zA-Z]*[0-9]+""".r
+        val regex = fullPortRegex.r
         port match {
-            case regex() => new JDBCPortImpl(port)
+            case regex(_*) => new JDBCPortImpl(port)
             case _ => throw new IllegalArgumentException("Port is not valid!")
         }
     }

--- a/src/main/scala/com/actian/spark_vector/vector/VectorOps.scala
+++ b/src/main/scala/com/actian/spark_vector/vector/VectorOps.scala
@@ -108,30 +108,30 @@ trait VectorOps {
       val rdd = Vector.unloadVector(sc, table, vectorProps, metadata, selectColumns, whereClause, whereParams)
       externalizeRDD(rdd, StructType(metadata.map(_.structField)))
     }
-    
+
     // Used to encode InternalRow to external Row objects
     private def externalizeRDD(rdd: RDD[InternalRow], schema: StructType): RDD[Row] = {
       val encoder = RowEncoder(schema).resolveAndBind()
       rdd.map(encoder.fromRow(_))
     }
   }
-  
+
   /**
    * Wrapper class to expose Vector operations on DataFrameReader
-   * 
+   *
    * @param reader dataFrameReader used for read
    */
   implicit class VectorDataFrameReader(reader: DataFrameReader) {
     /**
      * Construct a `DataFrame` representing the vector database table accessible via the x100 engine.
-     * 
+     *
      * @param host Name of the vector host
-     * @param instance Name of the vector instance 
+     * @param instance Name of the vector instance
      * @param database Name of the vector database
      * @param table Name of the table to load
-     * @param properties Vector database connection arguments, a list of arbitrary string 
-     *                   tag/value. Normally at least a "user" and "password" property 
-     *                   should be included. Can also include a "cols" property consisting 
+     * @param properties Vector database connection arguments, a list of arbitrary string
+     *                   tag/value. Normally at least a "user" and "password" property
+     *                   should be included. Can also include a "cols" property consisting
      *                   of a comma separated list of the columns to write.
      */
     def vector(host: String, instance: String, database: String, table: String, properties: Properties) = {
@@ -139,45 +139,45 @@ trait VectorOps {
       options += ("host" -> host, "instance" -> instance, "database" -> database, "table" -> table)
       reader.format("vector").options(options).load()
     }
-    
+
     /**
      * Construct a `DataFrame` representing the vector database table accessible via the x100 engine.
-     * 
+     *
      * @param vectorProps connection properties to the Vector instance
      * @param table name of the table to load
-     * @param properties Vector database connection arguments, a list of arbitrary string 
-     *                   tag/value. Can include a "cols" property consisting 
+     * @param properties Vector database connection arguments, a list of arbitrary string
+     *                   tag/value. Can include a "cols" property consisting
      *                   of a comma separated list of the columns to write.
      */
     def vector(vectorProps: VectorConnectionProperties, table: String, properties: Properties) = {
       var options: Map[String, String] = properties.asScala.toMap
-      options += ("host" -> vectorProps.host, "instance" -> vectorProps.instance, 
-                  "database" -> vectorProps.database, "port" -> vectorProps.port, "table" -> table)
+      options += ("host" -> vectorProps.host, "database" -> vectorProps.database, "port" -> vectorProps.port.value,
+                  "table" -> table)
       if (vectorProps.user.isDefined) options += ("user" -> vectorProps.user.get)
       if (vectorProps.user.isDefined) options += ("password" -> vectorProps.password.get)
       reader.format("vector").options(options).load()
     }
   }
-  
+
   /**
    * Wrapper class to expose Vector Operations on DataFrameWriter
-   * 
+   *
    * @param writer dataFrameWriter used for write
    */
   implicit class VectorDataFrameWriter(writer: DataFrameWriter[Row]) {
     /**
      * Saves the content of the `DataFrame` to an external vector database table accessible via the x100 engine.
-     * 
+     *
      * @param host Name of the vector host
-     * @param instance Name of the vector instance 
+     * @param instance Name of the vector instance
      * @param database Name of the vector database
      * @param table Name of the table to unload
-     * @param properties Vector database connection arguments, a list of arbitrary string 
-     *                   tag/value. Normally at least a "user" and "password" property 
-     *                   should be included. Can include a "cols" property consisting 
-     *                   of a comma separated list of the columns to read. May also 
-     *                   include "loadpresql" and "loadpostsql" properties containing 
-     *                   any sql commands which should be run before or after the 
+     * @param properties Vector database connection arguments, a list of arbitrary string
+     *                   tag/value. Normally at least a "user" and "password" property
+     *                   should be included. Can include a "cols" property consisting
+     *                   of a comma separated list of the columns to read. May also
+     *                   include "loadpresql" and "loadpostsql" properties containing
+     *                   any sql commands which should be run before or after the
      *                   DataFrame is written to the table.
      */
     def vector(host: String, instance: String, database: String, table: String, properties: Properties) = {
@@ -185,29 +185,29 @@ trait VectorOps {
       options += ("host" -> host, "instance" -> instance, "database" -> database, "table" -> table)
       writer.format("vector").options(options).save()
     }
-    
+
     /**
      * Saves the content of the `DataFrame` to an external vector database table accessible via the x100 engine.
-     * 
+     *
      * @param vectorProps connection properties to the Vector instance
      * @param table name of the table to unload
-     * @param properties Vector database connection arguments, a list of arbitrary string 
-     *                   tag/value. Can include a "cols" property consisting 
-     *                   of a comma separated list of the columns to read. May also 
-     *                   include "loadpresql" and "loadpostsql" properties containing 
-     *                   any sql commands which should be run before or after the 
+     * @param properties Vector database connection arguments, a list of arbitrary string
+     *                   tag/value. Can include a "cols" property consisting
+     *                   of a comma separated list of the columns to read. May also
+     *                   include "loadpresql" and "loadpostsql" properties containing
+     *                   any sql commands which should be run before or after the
      *                   DataFrame is written to the table.
      */
     def vector(vectorProps: VectorConnectionProperties, table: String, properties: Properties) = {
       var options: Map[String, String] = properties.asScala.toMap
-      options += ("host" -> vectorProps.host, "instance" -> vectorProps.instance, 
-                  "database" -> vectorProps.database, "port" -> vectorProps.port, "table" -> table)
+      options += ("host" -> vectorProps.host, "database" -> vectorProps.database,
+                  "port" -> vectorProps.port.value, "table" -> table)
       if (vectorProps.user.isDefined) options += ("user" -> vectorProps.user.get)
       if (vectorProps.user.isDefined) options += ("password" -> vectorProps.password.get)
       writer.format("vector").options(options).save()
     }
   }
-  
+
 }
 
 object VectorOps extends VectorOps

--- a/src/test/scala/com/actian/spark_vector/vector/VectorConnectionPropertiesTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorConnectionPropertiesTest.scala
@@ -22,9 +22,11 @@ class VectorConnectionPropertiesTest extends FunSuite with Matchers with Propert
   val validCombos = Table(
     ("host",          "instance", "instanceOffset", "port",       "database",   "user",      "password",  "expectedURL"),
     ("host.com",      Some("VH"), None,             None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:VH7/db"),
-    ("host.com",      Some("VH"), Some("8"),        None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:VH8/db"),
+	("host.com",      Some("VH"), Some("8"),        None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:VH8/db"),
+	("host.com",      Some("A1"), Some("8"),        None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:A18/db"),
     ("some.host.com", None,       None,             Some("9000"), "db",         None,         None,       "jdbc:ingres://some.host.com:9000/db"),
-    ("justhost",      None,       None,             Some("VW8"),  "mydatabase", None,         None,       "jdbc:ingres://justhost:VW8/mydatabase"))
+	("justhost",      None,       None,             Some("VW8"),  "mydatabase", None,         None,       "jdbc:ingres://justhost:VW8/mydatabase"),
+	("justhost",      None,       None,             Some("A18"),  "mydatabase", None,         None,       "jdbc:ingres://justhost:A18/mydatabase"))
 
   val invalidCombos = Table(
     (null, "database"),
@@ -45,7 +47,8 @@ class VectorConnectionPropertiesTest extends FunSuite with Matchers with Propert
     (None,       Some("7"),        Some("9")),
     (Some("8"),  None,             None    ),
     (Some("VW"), Some("A"),        None    ),
-    (None,       None,             Some("VW")))
+	(None,       None,             Some("VW")),
+	(None,       None,             Some("W1")))
 
   test("valid URL and values") {
     forAll(validCombos) { (host: String, instance: Option[String], instanceOffset: Option[String], port: Option[String], database: String, user: Option[String], password: Option[String], expectedURL: String) =>

--- a/src/test/scala/com/actian/spark_vector/vector/VectorConnectionPropertiesTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorConnectionPropertiesTest.scala
@@ -20,44 +20,69 @@ import org.scalatest.prop.PropertyChecks
 
 class VectorConnectionPropertiesTest extends FunSuite with Matchers with PropertyChecks {
   val validCombos = Table(
-    ("host", "instance", "database", "user", "password", "expectedURL"),
-    ("host.com", "VH", "db", Some("user"), Some("pw"), "jdbc:ingres://host.com:VH7/db"),
-    ("some.host.com", "VW", "db", None, None, "jdbc:ingres://some.host.com:VW7/db"),
-    ("justhost", "99", "mydatabase", None, None, "jdbc:ingres://justhost:997/mydatabase"))
+    ("host",          "instance", "instanceOffset", "port",       "database",   "user",      "password",  "expectedURL"),
+    ("host.com",      Some("VH"), None,             None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:VH7/db"),
+    ("host.com",      Some("VH"), Some("8"),        None,         "db",         Some("user"), Some("pw"), "jdbc:ingres://host.com:VH8/db"),
+    ("some.host.com", None,       None,             Some("9000"), "db",         None,         None,       "jdbc:ingres://some.host.com:9000/db"),
+    ("justhost",      None,       None,             Some("VW8"),  "mydatabase", None,         None,       "jdbc:ingres://justhost:VW8/mydatabase"))
 
   val invalidCombos = Table(
-    ("host", "instance", "database"),
-    (null, "VW", "database"),
-    ("", "VW", "database"),
-    ("host.com", null, "db"),
-    ("host.com", "", "db"),
-    ("host.com", "VW", null),
-    ("host.com", "VW", ""))
+    (null, "database"),
+    ("", "database"),
+    ("host.com", null),
+    ("host.com", ""))
+
+  val invalidCombos2 = Table(
+    ("instance", "instanceOffset", "port"  ),
+    (None,       None,             None    ),
+    (Some(""),   None,             None    ),
+    (Some("VW"), None,             Some("7")),
+    (Some("VW"), Some("7"),        Some("7")),
+    (Some("VW"), Some(""),         None    ),
+    (Some("VW"), Some(""),         Some("")),
+    (Some("VW"), None,             Some("")),
+    (None,       None,             Some("")),
+    (None,       Some("7"),        Some("9")),
+    (Some("8"),  None,             None    ),
+    (Some("VW"), Some("A"),        None    ),
+    (None,       None,             Some("VW")))
 
   test("valid URL and values") {
-    forAll(validCombos) { (host: String, instance: String, database: String, user: Option[String], password: Option[String], expectedURL: String) =>
-      // With user & password
-      val props = VectorConnectionProperties(host, instance, database, user, password)
-      validate(props, host, instance, database, user, password, expectedURL)
+    forAll(validCombos) { (host: String, instance: Option[String], instanceOffset: Option[String], port: Option[String], database: String, user: Option[String], password: Option[String], expectedURL: String) =>
+        var jdbcPort: Option[JDBCPort] = None
+        noException shouldBe thrownBy {
+            jdbcPort = Some(JDBCPort(instance, instanceOffset, port))
+        }
+        // With user & password
+          val props = VectorConnectionProperties(host, jdbcPort.get, database, user, password)
+          validate(props, host, jdbcPort.get, database, user, password, expectedURL)
 
-      // Without user & password
-      val props2 = VectorConnectionProperties(host, instance, database)
-      validate(props2, host, instance, database, None, None, expectedURL)
+          // Without user & password
+          val props2 = VectorConnectionProperties(host, jdbcPort.get, database)
+          validate(props2, host, jdbcPort.get, database, None, None, expectedURL)
     }
   }
 
-  test("invalid vector properties") {
-    forAll(invalidCombos) { (host: String, instance: String, database: String) =>
+  test("invalid host or database") {
+    forAll(invalidCombos) { (host: String, database: String) =>
       a[IllegalArgumentException] should be thrownBy {
-        VectorConnectionProperties(host, instance, database)
+        VectorConnectionProperties(host, JDBCPort(None, None, Some("9999")), database)
       }
     }
   }
 
-  private def validate(props: VectorConnectionProperties, host: String, instance: String, database: String, user: Option[String], password: Option[String], expectedURL: String): Unit = {
+  test("invalid instance or instanceOffset or port") {
+    forAll(invalidCombos2) { (instance: Option[String], instanceOffset: Option[String], port: Option[String]) =>
+        a[IllegalArgumentException] should be thrownBy {
+            val jdbcPort = JDBCPort(instance, instanceOffset, port)
+        }
+    }
+  }
+
+  private def validate(props: VectorConnectionProperties, host: String, port: JDBCPort, database: String, user: Option[String], password: Option[String], expectedURL: String): Unit = {
     props.toJdbcUrl should be(expectedURL)
     props.host should be(host)
-    props.instance should be(instance)
+    props.port.value should be(port.value)
     props.database should be(database)
     props.user should be(user)
     props.password should be(password)

--- a/src/test/scala/com/actian/spark_vector/vector/VectorFixture.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorFixture.scala
@@ -30,7 +30,7 @@ trait VectorFixture {
   def connectionProps: VectorConnectionProperties = {
     val host = System.getProperty("vector.host", "")
     val instance = System.getProperty("vector.instance", "")
-    val instanceOffset = System.getProperty("vector.instanceOffset", "7")
+    val instanceOffset = System.getProperty("vector.instanceOffset", JDBCPort.defaultInstanceOffset)
     val jdbcPort = System.getProperty("vector.jdbcPort", "")
     val database = System.getProperty("vector.database", "")
     val user = System.getProperty("vector.user", "")

--- a/src/test/scala/com/actian/spark_vector/vector/VectorFixture.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorFixture.scala
@@ -30,12 +30,14 @@ trait VectorFixture {
   def connectionProps: VectorConnectionProperties = {
     val host = System.getProperty("vector.host", "")
     val instance = System.getProperty("vector.instance", "")
+    val instanceOffset = System.getProperty("vector.instanceOffset", "7")
+    val jdbcPort = System.getProperty("vector.jdbcPort", "")
     val database = System.getProperty("vector.database", "")
     val user = System.getProperty("vector.user", "")
     val password = System.getProperty("vector.password", "")
-    val port = System.getProperty("vector.port", "7")
 
-    VectorConnectionProperties(host, instance, database, Some(user).filter(!_.isEmpty), Some(password).filter(!_.isEmpty), port)
+    VectorConnectionProperties(host, JDBCPort(Some(instance).filter(!_.isEmpty), Some(instanceOffset).filter(!_.isEmpty), Some(jdbcPort).filter(!_.isEmpty)),
+        database, Some(user).filter(!_.isEmpty), Some(password).filter(!_.isEmpty))
   }
 
   def nameNodeAddr = System.getProperty("vector.namenode.address", "hdfs://hornet:8020/")
@@ -45,8 +47,8 @@ trait VectorFixture {
     val colDefs = columnMD.map(columnMD => {
       Seq[String](columnMD.name, columnMD.typeName, if (!columnMD.nullable) "not null" else "").mkString(" ")
     }).mkString("(", ", ", ")")
-    
-    val partitions = if (connectionProps.instance.toUpperCase().contains("H")) {
+
+    val partitions = if (connectionProps.port.value.toUpperCase().contains("H")) {
       // TODO: Need to determine best way to dynamically specify partitions for tests
       " WITH NOPARTITION"
     } else {
@@ -88,7 +90,7 @@ trait VectorFixture {
   def admitRDDWithNulls(sparkContext: SparkContext): (RDD[Row], StructType) =
     createAdmitRDD(sparkContext, admitDataWithNulls)
 
-  def admitDataStatements(): Seq[Any] = 
+  def admitDataStatements(): Seq[Any] =
     admitData.map(_.mkString("(", ",", ")"))
 
   private val admitData = Seq(

--- a/src/test/scala/com/actian/spark_vector/vector/VectorJDBCTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorJDBCTest.scala
@@ -15,7 +15,7 @@
  */
 package com.actian.spark_vector.vector
 
-import java.sql.SQLNonTransientConnectionException
+import java.sql.{SQLNonTransientConnectionException, SQLException}
 
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
@@ -23,6 +23,8 @@ import com.actian.spark_vector.test.IntegrationTest
 import com.actian.spark_vector.vector.ErrorCodes._
 import com.actian.spark_vector.vector.VectorFixture._
 import com.actian.spark_vector.vector.VectorJDBC._
+import org.apache.spark.Success
+import org.scalacheck.Test.Failed
 
 /**
  * Tests of VectorJDBC
@@ -72,11 +74,15 @@ class VectorJDBCTest extends FunSuite with BeforeAndAfter with Matchers with Vec
   }
 
   test("bad connection") {
-    val badCxnProps = VectorConnectionProperties("host", "instance", "database", Some("user"), Some("pw"))
-    intercept[SQLNonTransientConnectionException] {
-      withJDBC(badCxnProps) { cxn =>
+    val badCxnProps = VectorConnectionProperties("host", JDBCPort(Some("instance"), None, None), "database", Some("user"), Some("pw"))
+    try {
+        withJDBC(badCxnProps) { cxn =>
         assert(false, "should not get here")
       }
+    }
+    catch {
+        case  _ : SQLNonTransientConnectionException | _ : SQLException => Success
+        case _ : Throwable => Failed
     }
   }
 

--- a/src/test/scala/com/actian/spark_vector/vector/VectorJDBCTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorJDBCTest.scala
@@ -74,7 +74,7 @@ class VectorJDBCTest extends FunSuite with BeforeAndAfter with Matchers with Vec
   }
 
   test("bad connection") {
-    val badCxnProps = VectorConnectionProperties("host", JDBCPort(Some("instance"), None, None), "database", Some("user"), Some("pw"))
+    val badCxnProps = VectorConnectionProperties("host", JDBCPort(Some("VW"), None, None), "database", Some("user"), Some("pw"))
     try {
         withJDBC(badCxnProps) { cxn =>
         assert(false, "should not get here")

--- a/src/test/scala/com/actian/spark_vector/vector/VectorTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorTest.scala
@@ -56,7 +56,7 @@ class VectorTest extends FunSuite with Matchers with PropertyChecks with VectorF
   test("getTableSchema with bad cxn props", IntegrationTest) {
     withTable(func => Unit) { tableName =>
       val ex = intercept[VectorException] {
-        VectorUtil.getTableSchema(VectorConnectionProperties("host", "instance", "db"), tableName)
+        VectorUtil.getTableSchema(VectorConnectionProperties("host", JDBCPort(Some("instance"), None, None), "db"), tableName)
       }
 
       ex.errorCode should be(SqlException)

--- a/src/test/scala/com/actian/spark_vector/vector/VectorTest.scala
+++ b/src/test/scala/com/actian/spark_vector/vector/VectorTest.scala
@@ -56,7 +56,7 @@ class VectorTest extends FunSuite with Matchers with PropertyChecks with VectorF
   test("getTableSchema with bad cxn props", IntegrationTest) {
     withTable(func => Unit) { tableName =>
       val ex = intercept[VectorException] {
-        VectorUtil.getTableSchema(VectorConnectionProperties("host", JDBCPort(Some("instance"), None, None), "db"), tableName)
+        VectorUtil.getTableSchema(VectorConnectionProperties("host", JDBCPort(Some("VW"), None, None), "db"), tableName)
       }
 
       ex.errorCode should be(SqlException)


### PR DESCRIPTION
enables specification of an explicit JDBC port as a
number, e.g. 9999, or as instance-offset-concatenation, e.g. VW7.
Note, -vi and -vo are still supported. However, usage
is exclusive -- EITHER -vj OR -vi (and -vo).